### PR TITLE
🔧 [WV-37] fix : 카카오맵 로드 문제 해결

### DIFF
--- a/app/(menu)/wizpark/iksan/page.tsx
+++ b/app/(menu)/wizpark/iksan/page.tsx
@@ -7,7 +7,6 @@ import { BusRouteInfo } from "@/components/wizpark/iksan/bus-route-info";
 import { IKSAN_IMAGES, IKSAN_LOCATION } from "@/constants/stadium";
 import { Bus, ExternalLink, Images, Map, MapPin } from "lucide-react";
 import Link from "next/link";
-import Script from "next/script";
 
 export default function page() {
   return (
@@ -32,10 +31,6 @@ export default function page() {
           </div>
         </CardContent>
       </Card>
-      <Script
-        strategy="beforeInteractive"
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services&autoload=false`}
-      />
       <CardHeader>
         <CardTitle className="flex items-center">
           <Map className="mr-2" />

--- a/app/(menu)/wizpark/location/page.tsx
+++ b/app/(menu)/wizpark/location/page.tsx
@@ -2,7 +2,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import KakaoMap from "@/components/common/Map";
 import { Bus, ExternalLink, Map, MapPin, MoveRight, Train } from "lucide-react";
 import Link from "next/link";
-import Script from "next/script";
 import { SUWON_LOCATION } from "@/constants/stadium";
 
 export default function page() {
@@ -10,10 +9,6 @@ export default function page() {
 
   return (
     <div>
-      <Script
-        strategy="beforeInteractive"
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services&autoload=false`}
-      />
       <CardHeader>
         <CardTitle className="flex items-center">
           <Map className="mr-2" />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import { Noto_Sans_KR } from "next/font/google";
 import QueryProviders from "@/providers/query-provider";
+import Script from "next/script";
 
 const notoSansKr = Noto_Sans_KR({
   subsets: ["latin"],
@@ -25,6 +26,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <Script
+        strategy="afterInteractive"
+        src={`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services&autoload=false`} />
       <body className={notoSansKr.className}>
         <div className="flex flex-col min-h-screen">
           <Header />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,10 +26,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <Script
-        strategy="afterInteractive"
-        src={`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services&autoload=false`} />
       <body className={notoSansKr.className}>
+        <Script
+          strategy="afterInteractive"
+          src={`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services&autoload=false`} />
         <div className="flex flex-col min-h-screen">
           <Header />
           <main className="flex-1">


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->
카카오맵을 보여주는 페이지에서 새로고침한 후에만 렌더링되었던 문제를 해결하였습니다.

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->

### 버그 발생 상황
1. 카카오맵을 로드하는 페이지 접속한다.
2. 카카오맵이 보이지 않는다.
3. 새로고침을 한다.
4. 카카오맵이 렌더링된다.
...
5. 다른 페이지에 접속한다.
6. 다시 카카오맵 페이지에 접속한다.
7. 새로고침을 하지 않아도 카카오맵이 보인다.

### 접근 방식
만약, 단순 내부 컴포넌트의 로직 문제라면 페이지에 들어올 때마다 새로고침을 해주어야 할텐데, 한번 새로고침하면 해당 버그가 발생하지 않는다는 점에 주목하여 접근했습니다.

next-script(Script태그)로 카카오 SDK를 로드하였었는데, 해당 태그는 '카카오맵을 보여주는 페이지 컴포넌트'에 위치되어있었습니다. 그렇기 때문에 페이지에 진입 후 SDK가 로드가 되기 전에 카카오맵을 불러오기 때문에 렌더링되지 않았던 이유였습니다.

### 해결방법
SDK 로드 시점을 루트 레이아웃에 배치하여 웹이 실행되었을 시점에 한번만 로드되도록 스크립트 코드 위치를 변경하였습니다. 

이제 페이지 진입하면 새로고침하지 않아도 정상적으로 바로 로드되어 카카오맵을 보여줍니다.



<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```